### PR TITLE
Use recent `arduino_ci` for testing; move scripts to new directory

### DIFF
--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -1,18 +1,3 @@
-# https://github.com/Arduino-CI/arduino_ci/issues/159
-# copied from vendor/bundle/ruby/2.6.0/gems/arduino_ci-0.3.0/misc/default.yml
-platforms:
-  mega2560:
-    board: arduino:avr:mega:cpu=atmega2560
-    package: arduino:avr
-    gcc:
-      features:
-      defines:
-        - __AVR_ATmega2560__
-        # added this line
-        - ARDUINO_CI
-        - __AVR__
-      warnings:
-      flags:
 
 unittest:
   platforms:
@@ -21,10 +6,10 @@ unittest:
     reject:
       - "Common.cpp"
   libraries:
-    - "Adafruit BusIO"
+    - "Adafruit_BusIO"
 
 compile:
   platforms:
     - mega2560
   libraries:
-    - "Adafruit BusIO"
+    - "Adafruit_BusIO"

--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -6,10 +6,10 @@ unittest:
     reject:
       - "Common.cpp"
   libraries:
-    - "Adafruit_BusIO"
+    - "Adafruit BusIO"
 
 compile:
   platforms:
     - mega2560
   libraries:
-    - "Adafruit_BusIO"
+    - "Adafruit BusIO"

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'arduino_ci'
+gem 'arduino_ci', git: 'https://github.com/Arduino-CI/arduino_ci.git', branch: 'master'

--- a/scripts/install_libraries.sh
+++ b/scripts/install_libraries.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# set up directories
+bundle exec ensure_arduino_installation.rb
+
+# get custom version of Adafruit_BusIO
+git clone https://github.com/Arduino-CI/Adafruit_BusIO.git
+mv Adafruit_BusIO $(bundle exec arduino_library_location.rb)

--- a/scripts/install_libraries.sh
+++ b/scripts/install_libraries.sh
@@ -5,4 +5,4 @@ bundle exec ensure_arduino_installation.rb
 
 # get custom version of Adafruit_BusIO
 git clone https://github.com/Arduino-CI/Adafruit_BusIO.git
-mv Adafruit_BusIO $(bundle exec arduino_library_location.rb)
+mv Adafruit_BusIO "$(bundle exec arduino_library_location.rb)/Adafruit BusIO"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+bundle config --local path vendor/bundle
+bundle install
+bundle exec arduino_ci.rb  --skip-examples-compilation

--- a/scripts/testAndBuild.sh
+++ b/scripts/testAndBuild.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 bundle config --local path vendor/bundle
-bundle exec arduino_ci_remote.rb
+bundle install
+bundle exec arduino_ci.rb

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,0 @@
-#! /bin/sh
-bundle config --local path vendor/bundle
-bundle exec arduino_ci_remote.rb  --skip-compilation


### PR DESCRIPTION
By installing Adafruit_BusIO and by making the change in https://github.com/Arduino-CI/arduino_ci/pull/213 I'm able to get the tests to run but there are several failures. Let's look at this some more...